### PR TITLE
Feeds only .brs files to linter. XML files were returning an error.

### DIFF
--- a/lib/utils/inserter.js
+++ b/lib/utils/inserter.js
@@ -98,9 +98,8 @@ function compile(directory, constants, ignoreErrors) {
     fs.writeFileSync(file, src)
   })
 
-  brsFiles = sourceFiles.filter(file => file.endsWith('.brs'));
+  let brsFiles = sourceFiles.filter(file => file.endsWith('.brs'));
   runLinter(brsFiles, ignoreErrors)
- // runLinter(sourceFiles, ignoreErrors)
 }
 
 function runLinter(sourceFiles, ignoreErrors) {

--- a/lib/utils/inserter.js
+++ b/lib/utils/inserter.js
@@ -98,16 +98,18 @@ function compile(directory, constants, ignoreErrors) {
     fs.writeFileSync(file, src)
   })
 
-  runLinter(sourceFiles, ignoreErrors)
+  brsFiles = sourceFiles.filter(file => file.endsWith('.brs'));
+  runLinter(brsFiles, ignoreErrors)
+ // runLinter(sourceFiles, ignoreErrors)
 }
 
 function runLinter(sourceFiles, ignoreErrors) {
   try {
     const cliEngine = new CLIEngine()
     const lint = cliEngine.executeOnFiles(sourceFiles)
-     
+
     wistLogger.logResult(lint.results, ignoreErrors)
-  
+
     if (lint.errorCount > 0 && !ignoreErrors) {
       process.exit(-1)
     }


### PR DESCRIPTION
XML files are being fed to linter and returning all kinds of errors.