### PR TITLE
Add console option to ukor install

### DIFF
--- a/bin/ukor-install.js
+++ b/bin/ukor-install.js
@@ -3,6 +3,7 @@ const program = require('../lib/utils/log-commander')
 const properties = require('../lib/utils/properties')
 const utils = require('../lib/utils/utils')
 const log = require('../lib/utils/log')
+const { spawn } = require('child_process')
 
 program
   .arguments('[flavor] [roku]')
@@ -11,6 +12,7 @@ program
     'Specify a roku. Ignored if passed as argument.'
   )
   .option('-a, --auth <user:pass>', 'Set username and password for roku.')
+  .option('-c, --console', 'Launch the Roku Telnet console / debugger after installation')
   .parse(process.argv)
 
 let args = program.args
@@ -48,4 +50,12 @@ if (program['verbose']) {
 if (program['debug']) {
   log.level = 'debug'
 }
-install.install(options)
+install.install(options, function(ip, success) {
+  if (success && program.console) {
+    // launch the debugger
+    console = spawn('telnet', [ip, 8085], {
+      detached: true,
+      stdio: 'inherit'
+    })
+  }
+})

--- a/bin/ukor.js
+++ b/bin/ukor.js
@@ -11,7 +11,7 @@ program
     'Bundle your channel into a zip to the build directory'
   )
   .command(
-    'install [flavor] [roku]',
+    'install [flavor] [roku] [-c, --console]',
     'Bundle then deploy your channel to a named roku'
   )
   .command(


### PR DESCRIPTION
Adds the `-c` or `--console` option to `ukor install`. On install success, this immediately opens a `telnet` session to the Roku's console port 8085. 