### PR TITLE
Add console and debugger support

### DIFF
--- a/bin/ukor-console.js
+++ b/bin/ukor-console.js
@@ -1,0 +1,21 @@
+const telnet = require('../lib/commands/telnet')
+const program = require('../lib/utils/log-commander')
+const properties = require('../lib/utils/properties')
+const log = require('../lib/utils/log')
+
+program
+  .arguments('[roku]')
+  .option(
+    '-r, --roku <name|id|ip>',
+    'Specify a Roku. Ignored if passed as an argument'
+  )
+  .parse(process.argv)
+
+let args = program.args
+let roku = args[0] || properties.defaults.roku
+
+if (!roku) {
+  log.error('Must provide a Roku or IP to open')
+}
+
+telnet.console(roku)

--- a/bin/ukor-debugger.js
+++ b/bin/ukor-debugger.js
@@ -1,0 +1,21 @@
+const telnet = require('../lib/commands/telnet')
+const program = require('../lib/utils/log-commander')
+const properties = require('../lib/utils/properties')
+const log = require('../lib/utils/log')
+
+program
+  .arguments('[roku]')
+  .option(
+    '-r, --roku <name|id|ip>',
+    'Specify a Roku. Ignored if passed as an argument'
+  )
+  .parse(process.argv)
+
+let args = program.args
+let roku = args[0] || properties.defaults.roku
+
+if (!roku) {
+  log.error('Must provide a Roku or IP to open')
+}
+
+telnet.debugger(roku)

--- a/bin/ukor-install.js
+++ b/bin/ukor-install.js
@@ -3,6 +3,7 @@ const program = require('../lib/utils/log-commander')
 const properties = require('../lib/utils/properties')
 const utils = require('../lib/utils/utils')
 const log = require('../lib/utils/log')
+const telnet = require('../lib/commands/telnet')
 
 program
   .arguments('[flavor] [roku]')
@@ -11,6 +12,7 @@ program
     'Specify a roku. Ignored if passed as argument.'
   )
   .option('-a, --auth <user:pass>', 'Set username and password for roku.')
+  .option('-c, --console', 'Launch the Roku Telnet console / debugger after installation')
   .parse(process.argv)
 
 let args = program.args
@@ -48,4 +50,9 @@ if (program['verbose']) {
 if (program['debug']) {
   log.level = 'debug'
 }
-install.install(options)
+install.install(options, function(ip, success) {
+  if (success && program.console) {
+    // launch the console
+    telnet.console(ip)
+  }
+})

--- a/bin/ukor.js
+++ b/bin/ukor.js
@@ -11,12 +11,20 @@ program
     'Bundle your channel into a zip to the build directory'
   )
   .command(
-    'install [flavor] [roku]',
+    'install [flavor] [roku] [-c, --console]',
     'Bundle then deploy your channel to a named roku'
   )
   .command(
     'package <flavor> <roku>',
     'Package a channel flavor with a roku device'
+  )
+  .command(
+    'console [roku]',
+    'Launch the Telnet console for the named roku'
+  )
+  .command(
+    'debugger [roku]',
+    'Launch the Telnet debugger for the named roku'
   )
   .command('find', 'Search for rokus on the network')
   .command('init [flavors...]', 'Initialize a ukor project')

--- a/lib/commands/telnet.js
+++ b/lib/commands/telnet.js
@@ -1,0 +1,50 @@
+const utils = require('../utils/utils')
+const find = require('./find')
+const log = require('../utils/log')
+const properties = require('../utils/properties')
+const { spawn } = require('child_process')
+
+function findRokuAndExecute(roku, callback) {
+  let rokuType = utils.parseRoku(roku)
+  if (rokuType== 'ip') {
+    callback(roku)
+  } else {
+    let usn = ''
+    if (rokuType == 'name') {
+      usn = properties.rokus[roku].serial
+    } else {
+      usn = roku
+    }
+    find.usn(usn, 5, ip => {
+      if (ip) {
+        callback(ip)
+      } else {
+        log.error('Unable to find Roku %s', roku)
+      }
+    })
+  }
+}
+
+function openTelnet(ip, port) {
+  spawn('telnet', [ip, port], {
+    detached: true,
+    stdio: 'inherit'
+  })
+}
+
+function openConsole(ip) {
+  openTelnet(ip, 8085)
+}
+
+function openDebugger(ip) {
+  openTelnet(ip, 8080)
+}
+
+module.exports = {
+  console: (roku) => {
+    findRokuAndExecute(roku, openConsole)
+  },
+  debugger: (roku) => {
+    findRokuAndExecute(roku, openDebugger)
+  }
+}


### PR DESCRIPTION
Adds two commands to ukor:
- `ukor console <roku>` launches the Telnet console for the named Roku
- `ukor debugger <roku>` launches the Telnet debug terminal for the named Roku

Also adds a `-c, --console` option for `ukor install`, which opens the Telnet console after a successful installation. 