### PR TITLE
Implement prebuild script feature

### DIFF
--- a/lib/commands/make.js
+++ b/lib/commands/make.js
@@ -7,6 +7,7 @@ const mkdirp = require('mkdirp')
 const fse = require('fs-extra')
 const rimraf = require('rimraf')
 const inserter = require('../utils/inserter')
+const childProcess = require('child_process')
 const temp = '.ukor'
 
 function moveToTempDir(flavor) {
@@ -30,7 +31,19 @@ function moveToTempDir(flavor) {
   }
 }
 
+function execPreBuildScript() {
+  if (properties.preBuild != null && properties.preBuild != '') {
+    log.info('exec ' + properties.preBuild)
+    let result = childProcess.execFileSync('node', [properties.preBuild])
+    if (log.level == 'verbose') {
+      log.verbose([properties.preBuild, 'exec:', result].join(' '))
+    }
+  }
+}
+
 function bundleFlavor(options, callback) {
+  execPreBuildScript()
+
   const flavor = options.flavor
   let flavorSrc = properties.flavors[flavor].src
   const build = options.build || properties.buildDir

--- a/lib/utils/schema.js
+++ b/lib/utils/schema.js
@@ -78,6 +78,10 @@ module.exports = {
       type: 'string',
       pattern: '\S*',
     },
+    preBuild: {
+      type: 'string',
+      pattern: '\S*',
+    },
     version: {
       type: 'string',
       pattern: '^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:[\+][0-9A-Za-z-]+)?$',


### PR DESCRIPTION
This pull-request will enable you to run an script file before build will be made. That will give you enough flexibility to customize you build and do other stuff before build is created.

How to use it:
Add `preBuild` field in `ukor.local` or `ukor.properties.yaml`, and populate the field with the path to your script.

Example:

ukor.properties.yaml
```
name: ukor
version: 0.0.1
buildDir: build
sourceDir: src
preBuild: scripts/test.js  <--
defaults:
  falvor: main
flavors:
  main:
    src:
      - main
```

Result after execution of `ukor install main roku -v`:
![image](https://user-images.githubusercontent.com/16267898/45614942-c5f56800-ba73-11e8-8865-76fba376a719.png)

