### PR TITLE
Add possibility to create release packages

### DIFF
--- a/bin/ukor-package.js
+++ b/bin/ukor-package.js
@@ -1,0 +1,59 @@
+const log = require('../lib/utils/log')
+const utils = require('../lib/utils/utils')
+const install = require('../lib/commands/install')
+const package = require('../lib/commands/package')
+const properties = require('../lib/utils/properties')
+const program = require('../lib/utils/log-commander')
+
+program
+  .arguments('[flavor] [roku]')
+  .option(
+    '-r, --roku <name|id|ip>',
+    'Specify a roku. Ignored if passed as argument.'
+  )
+  .parse(process.argv)
+
+let args = program.args
+let flavor = args[0] || properties.defaults['flavor']
+let roku = args[1] || program.roku || properties.defaults.roku
+
+try {
+    var auth = program.auth || properties.rokus[roku]['auth']
+    if (typeof(auth) === 'string') {
+      auth = {
+        user: auth.split(':')[0],
+        pass: auth.split(':')[1]
+      }
+    }
+} catch (e) {
+    log.error('no auth defined for roku: ' + roku)
+    process.exit(-1)
+}
+
+let options = {
+    flavor,
+    roku,
+    auth,
+    name: ''
+}
+for (let key in options) {
+    if (!options[key] && key != 'name') {
+      log.error('%s options is undefined')
+      log.pretty('error', 'options:', options)
+      process.exit(-1)
+    }
+}
+
+if (program['verbose']) {
+    log.level = 'verbose'
+}
+
+if (program['debug']) {
+    log.level = 'debug'
+}
+
+install.install(options, function(ip, success) {
+    if (success) {
+      package.package(options, ip)
+    }
+})

--- a/lib/commands/package.js
+++ b/lib/commands/package.js
@@ -45,10 +45,6 @@ function create(options, ip) {
   )
 }
 
-function parseBody(body) {
-  return body.match(/<a href=(.*?)>/g)
-}
-
 function download(options, ip, packageName) {
   request.get(
     {
@@ -90,6 +86,10 @@ function getAppName(options) {
     properties.name,
     options.flavor
   ].join('/')
+}
+
+function parseBody(body) {
+  return body.match(/<a href=(.*?)>/g)
 }
 
 module.exports = {

--- a/lib/commands/package.js
+++ b/lib/commands/package.js
@@ -65,7 +65,14 @@ function download(options, ip, packageName) {
         log.info('Creating package...')
       }
     }
-  ).pipe(fs.createWriteStream(properties.buildDir + '/release.pkg'))
+  ).pipe(fs.createWriteStream(getPackagePath(options)))
+}
+
+function getPackagePath(options) {
+  return [
+    properties.buildDir,
+    options.flavor
+  ].join('/').concat('.pkg')
 }
 
 function getPackageName(urls) {

--- a/lib/commands/package.js
+++ b/lib/commands/package.js
@@ -1,0 +1,92 @@
+const fs = require('fs')
+const path = require('path')
+const request = require('request')
+const log = require('../utils/log')
+const properties = require('../utils/properties')
+
+function create(options, ip) {
+  const curTime = new Date().getTime();
+
+  const zip = path.join(
+    properties.buildDir,
+    options.flavor + options.name + '.zip'
+  )
+  const form = {
+    app_name: getAppName(options),
+    mysubmit: 'Package',
+    pkg_time: curTime,
+    passwd: properties.packageKey
+  }
+
+  request.post(
+    {
+      url: 'http://' + ip + '/plugin_package',
+      formData: form,
+      auth: options.auth
+    },
+    (error, response, body) => {
+      if (error || !body) {
+        log.error('Generate package failed:')
+        log.error(error)
+        log.error('Failture http code:' + response.statusCode)
+      } else {
+        urls = parseBody(body)
+
+        if (urls) {
+          packageName = getPackageName(urls)
+          if (packageName != null) {
+            download(options, ip, packageName)
+          }
+        } else {
+          log.error('Falied to find the package in body response');
+        }
+      }
+    }
+  )
+}
+
+function parseBody(body) {
+  return body.match(/<a href=(.*?)>/g)
+}
+
+function download(options, ip, packageName) {
+  request.get(
+    {
+      url: 'http://' + ip + '/' + packageName,
+      auth: options.auth
+    },
+    (error, response, body) => {
+      if (error || !body) {
+        log.error('Download package failed:')
+        log.error(error)
+        log.error('Failture http code:' + response.statusCode)
+      } else {
+        log.verbose('Package was founded on roku device')
+        log.info('Creating package...')
+      }
+    }
+  ).pipe(fs.createWriteStream(properties.buildDir + '/release.pkg'))
+}
+
+function getPackageName(urls) {
+  let result = null
+
+  urls.map(function(val) {
+    result = val.split('"')[1];
+  })
+
+  return result
+}
+
+function getAppName(options) {
+  return [
+    properties.name,
+    options.flavor
+  ].join('/')
+}
+
+module.exports = {
+  package: (options, ip) => {
+    create(options, ip)
+  }
+}

--- a/lib/utils/schema.js
+++ b/lib/utils/schema.js
@@ -85,6 +85,10 @@ module.exports = {
     author: {
       type: 'string',
       pattern: '\S*',
+    },
+    packageKey: {
+      type: 'string',
+      pattern: '\S*',
     }
   }
 }


### PR DESCRIPTION
This pull-request enable users of ukor to create release packages directly from command line.

How to use it:
Add `packageKey` field in `ukor.local` or `ukor.properties.yaml`, and populate the field with your roku package key.

Example:

ukor.properties.yaml
```
name: ukor
version: 0.0.1
buildDir: build
sourceDir: src
packageKey: my_very_long_pkg_key  <--
defaults:
  falvor: main
flavors:
  main:
    src:
      - main
```

Result after execution of `ukor package main roku -v`:
![image](https://user-images.githubusercontent.com/16267898/45622436-a74f9b00-ba8c-11e8-82e2-42848ad50a88.png)
