### PR TITLE
Separate linting from build/install process

### DIFF
--- a/bin/ukor-lint.js
+++ b/bin/ukor-lint.js
@@ -1,0 +1,21 @@
+const log = require('../lib/utils/log')
+const utils = require('../lib/utils/utils')
+const lint = require('../lib/commands/lint')
+const program = require('../lib/utils/log-commander')
+const properties = require('../lib/utils/properties')
+
+program
+  .arguments('[flavor]')
+  .parse(process.argv)
+
+let args = program.args
+let flavor = args[0] || properties.defaults['flavor']
+
+if (flavor != null && flavor != '') {
+  if (properties.isFlavor(flavor)) {
+    let flavorSrc = [properties.sourceDir, flavor].join('/')
+    lint.lint(flavorSrc, false)
+  } else {
+    log.error(`Flavor can't be found: ${flavor}`)
+  }
+}

--- a/bin/ukor-make.js
+++ b/bin/ukor-make.js
@@ -9,14 +9,12 @@ program
   .arguments('[flavors...]')
   .option('-o, --out <out>', 'Specify a different build directory')
   .option('-l, --label <name>', 'Append a string to the zip name')
-  .option('-i, --ignore-errors', 'Don\'t fail the build if linting errors are found')
   .parse(process.argv)
 
 let args = program.args
 let build = program.out || properties.buildDir
 let name = program.label || ''
-let ignoreErrors = program.ignoreErrors || false
-let options = { build, name, ignoreErrors }
+let options = { build, name }
 
 if (args.length > 0) {
   args.forEach(flavor => {

--- a/bin/ukor.js
+++ b/bin/ukor.js
@@ -15,6 +15,10 @@ program
     'Package a channel flavor with a roku device'
   )
   .command(
+    'lint <flavor>',
+    'Lint a channel flavor'
+  )
+  .command(
     'console [roku]',
     'Launch the Telnet console for the named roku'
   )

--- a/lib/commands/lint.js
+++ b/lib/commands/lint.js
@@ -1,0 +1,14 @@
+const log = require('../utils/log')
+const utils = require('../utils/utils')
+const linter = require('../utils/linter')
+
+function lint(directory, ignoreErrors) {
+  log.info('Getting source files')
+  let sourceFiles = utils.getAllSourceFiles(directory)
+  log.info('Run linter...')
+  linter.run(sourceFiles, ignoreErrors)
+}
+
+module.exports = {
+  lint
+}

--- a/lib/utils/inserter.js
+++ b/lib/utils/inserter.js
@@ -6,25 +6,7 @@ const yaml = require('js-yaml')
 const merge = require('object-merge')
 const properties = require('./properties')
 const os = require('os')
-const CLIEngine = require('@willowtreeapps/wist').CLIEngine
-const wistLogger = require('./wist-logger')
-
-function getAllSourceFiles(dir) {
-  let src = []
-  let files = fs.readdirSync(dir)
-  files.forEach(file => {
-    let filepath = path.join(dir, file)
-    let stats = fs.statSync(filepath)
-    if (stats.isDirectory()) {
-      src = src.concat(getAllSourceFiles(filepath))
-    } else if (
-      stats.isFile() && (filepath.endsWith('.brs') || filepath.endsWith('.xml'))
-    ) {
-      src.push(filepath)
-    }
-  })
-  return src
-}
+const utils = require('./utils')
 
 function getConstant(value, constants) {
   const keys = value.split('.')
@@ -87,8 +69,8 @@ function insertConstants(src, constants, filename) {
   return src
 }
 
-function compile(directory, constants, ignoreErrors) {
-  let sourceFiles = getAllSourceFiles(directory)
+function compile(directory, constants) {
+  let sourceFiles = utils.getAllSourceFiles(directory)
 
   sourceFiles.forEach(file => {
     let srcData = fs.readFileSync(file)
@@ -96,24 +78,6 @@ function compile(directory, constants, ignoreErrors) {
 
     fs.writeFileSync(file, src)
   })
-
-  let brsFiles = sourceFiles.filter(file => file.endsWith('.brs'))
-  runLinter(brsFiles, ignoreErrors)
-}
-
-function runLinter(sourceFiles, ignoreErrors) {
-  try {
-    const cliEngine = new CLIEngine()
-    const lint = cliEngine.executeOnFiles(sourceFiles)
-
-    wistLogger.logResult(lint.results, ignoreErrors)
-
-    if (lint.errorCount > 0 && !ignoreErrors) {
-      process.exit(-1)
-    }
-  } catch (e){
-    log.warn(`Skipping Wist: ${e.message}`)
-  }
 }
 
 function mergeConstants(flavors) {

--- a/lib/utils/linter.js
+++ b/lib/utils/linter.js
@@ -1,0 +1,27 @@
+const log = require('./log')
+const wistLogger = require('./wist-logger')
+const CLIEngine = require('@willowtreeapps/wist').CLIEngine
+
+function run(sourceFiles, ignoreErrors) {
+  try {
+    const cliEngine = new CLIEngine()
+    brsFiles = getBrsFiles(sourceFiles)
+
+    let lint = cliEngine.executeOnFiles(brsFiles)
+    wistLogger.logResult(lint.results, ignoreErrors)
+
+    if (lint.errorCount > 0 && !ignoreErrors) {
+      process.exit(-1)
+    }
+  } catch (e){
+    log.warn(`Skipping Wist: ${e.message}`)
+  }
+}
+
+function getBrsFiles(sourceFiles) {
+  return sourceFiles.filter(file => file.endsWith('.brs'))
+}
+
+module.exports = {
+  run
+}

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -24,33 +24,39 @@ function getAllSourceFiles(dir) {
   return src
 }
 
-module.exports = {
-  parseRoku: (arg) => {
-    if (Object.keys(properties.rokus).includes(arg)) {
-      return 'name'
-    } else if (arg.match(matchers.ip)) {
-      return 'ip'
-    } else if (arg.match(matchers.usn)) {
-      return 'usn'
-    } else {
-      return null
-    }
-  },
-  parseAuth: (auth) => {
-    var splits = auth.split(':')
-    if (splits.length == 2) {
-      return {
-        user: splits[0],
-        pass: splits[1]
-      }
-    }
+function parseRoku(arg){
+  if (Object.keys(properties.rokus).includes(arg)) {
+    return 'name'
+  } else if (arg.match(matchers.ip)) {
+    return 'ip'
+  } else if (arg.match(matchers.usn)) {
+    return 'usn'
+  } else {
     return null
-  },
-  continueIfExists: (object, message) => {
-    if (!object) {
-      log.error(message)
-      process.exit(-1)
+  }
+}
+
+function parseAuth(auth) {
+  var splits = auth.split(':')
+  if (splits.length == 2) {
+    return {
+      user: splits[0],
+      pass: splits[1]
     }
-  },
+  }
+  return null
+}
+
+function continueIfExists(object, message) {
+  if (!object) {
+    log.error(message)
+    process.exit(-1)
+  }
+}
+
+module.exports = {
+  parseRoku,
+  parseAuth,
+  continueIfExists,
   getAllSourceFiles
 }

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -7,6 +7,23 @@ const matchers = {
   usn: /^[A-Z0-9]{12}$/
 }
 
+function getAllSourceFiles(dir) {
+  let src = []
+  let files = fs.readdirSync(dir)
+  files.forEach(file => {
+    let filepath = path.join(dir, file)
+    let stats = fs.statSync(filepath)
+    if (stats.isDirectory()) {
+      src = src.concat(getAllSourceFiles(filepath))
+    } else if (
+      stats.isFile() && (filepath.endsWith('.brs') || filepath.endsWith('.xml'))
+    ) {
+      src.push(filepath)
+    }
+  })
+  return src
+}
+
 module.exports = {
   parseRoku: (arg) => {
     if (Object.keys(properties.rokus).includes(arg)) {
@@ -34,5 +51,6 @@ module.exports = {
       log.error(message)
       process.exit(-1)
     }
-  }
+  },
+  getAllSourceFiles
 }

--- a/lib/utils/wist-logger.js
+++ b/lib/utils/wist-logger.js
@@ -41,12 +41,12 @@ module.exports = {
       logger
 
     if (errorTotal > 0 && ignoreErrors !== true) {
-      summary = `Build FAILED.${EOL}`
+      summary = `FAILED.${EOL}`
       logger = log.error
     }
     else {
-      summary = 'Build succeeded'
-            
+      summary = 'Succeed'
+
       if (errorTotal > 0 && ignoreErrors === true) {
         summary += ', with ignored errors'
       }


### PR DESCRIPTION
This pull-request will separate linting from build/install process.

Reason - for medium and big roku projects the linting process is very very slow because of the big number of files. So to install or create a build will take too long time. (example: ~30 mins on a project that have 266 brs files)

After this changes you will still be enable to use linting tool (wist) with command:
`ukor lint <flavor>`

Example:
![image](https://user-images.githubusercontent.com/16267898/45685143-14c4ff80-bb51-11e8-95ce-4946036bcd95.png)

`~30 mins on a project that have 266 brs files` - was obtained on this configuration:
![image](https://user-images.githubusercontent.com/16267898/45685926-9e75cc80-bb53-11e8-8d5f-a3e9d209dcd2.png)
