### PR TITLE
Override flavor sources in the given order

### DIFF
--- a/lib/utils/properties.js
+++ b/lib/utils/properties.js
@@ -45,7 +45,7 @@ function readProperties() {
     if (properties.flavors[f].base) {
       properties.flavors[f].src = properties.flavors[properties.flavors[f].base].src.concat(properties.flavors[f].src)
     } else {
-      properties.flavors[f].src = properties.flavors[f].src.reverse()
+      properties.flavors[f].src = properties.flavors[f].src
     }
   }
 }


### PR DESCRIPTION
The problem:
If you have an flavor defined with 2 or more sources, they will be override in reverse direction those given. So source2 will be override by source1, what is confusing for the users.
```
flavors:
 flavor_name:
    src:
      - source1
      - source2
```

This pull request will doing flavor source overrides in the given order.