### PR TITLE
removing dir creation / passing  host ip as optional config

### DIFF
--- a/lib/commands/make.js
+++ b/lib/commands/make.js
@@ -11,7 +11,7 @@ const childProcess = require('child_process')
 const temp = '.ukor'
 
 function moveToTempDir(flavor) {
-  mkdirp(temp)
+  //mkdirp(temp)  <- seems like extra step that gives us problems later
   if (fs.existsSync(flavor)) {
     fse.copySync(flavor, temp, {
       filter: name => {

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -65,8 +65,8 @@ function runLogServer(ip, port, timeout, callback) {
       })
     })
   })
-  logServer.listen(parseInt(port), getIP.address(), () => {
-    log.info('listening for tests on %s:%s', getIP.address(), port)
+  logServer.listen(parseInt(port), getLocalIp(), () => {
+    log.info('listening for tests on %s:%s', getLocalIp(), port)
   })
   return logServer
 }
@@ -117,13 +117,17 @@ function writeJunit(stats) {
   log.info('successfully wrote junit xml')
 }
 
+function getLocalIp() {
+  return properties.localIp || getIP.address()
+}
+
 function runTests(ip, auth, port, callback) {
   setTimeout(() => {
     let url =
       'http://' +
       ip +
       ':8060/launch/dev?RunTests=true&host=' +
-      getIP.address() +
+      getLocalIp() +
       '&port=' +
       port
     log.debug('starting tests with: %s', url)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@willowtreeapps/ukor",
-  "version": "1.1.3",
+  "version": "1.1.5",
   "description": "Roku build tool with flavors and deployment",
   "keywords": [
     "roku",
@@ -44,7 +44,6 @@
     "@willowtreeapps/wist": "^2.0.1",
     "ajv": "^6.5.4",
     "ajv-keywords": "^3.2.0",
-    "xml2js": "^0.4.19",
     "archiver": "^3.0.0",
     "commander": "^2.18.0",
     "fs-extra": "^7.0.0",
@@ -57,7 +56,8 @@
     "request": "^2.88.0",
     "rimraf": "^2.6.2",
     "winston": "^3.1.0",
-    "xml-writer": "^1.7.0"
+    "xml-writer": "^1.7.0",
+    "xml2js": "^0.4.19"
   },
   "devDependencies": {
     "eslint": "^4.19.1",


### PR DESCRIPTION
* removal of `mkdirp` since in jenkins it was breaking a CI flow because of existing directory error, while locally it didn't make any difference

* local host ip can be passed via properties (optional) since while testing in docker, `getIp` was giving an internal container address which doesn't work - [reference here](https://docs.docker.com/docker-for-mac/networking/#known-limitations-use-cases-and-workarounds)

* bumping build version
